### PR TITLE
fix rt-89404: read() does not overwrite local archname

### DIFF
--- a/lib/Test/Reporter.pm
+++ b/lib/Test/Reporter.pm
@@ -367,9 +367,10 @@ sub read {
           $self->{_from} = $content;
         } elsif ($header eq "Subject") {
           $self->{_subject} = $content;
-          my ($grade, $distribution) = (split /\s/, $content)[0,1];
+          my ($grade, $distribution, $archname) = (split /\s/, $content)[0..2];
           $self->{_grade} = lc $grade;
           $self->{_distribution} = $distribution;
+          $self->{_perl_version}{_archname} = $archname;
           $self->{_subject_lock} = 1;
         } elsif ($header eq "X-Test-Reporter-Distfile") {
           $self->{_distfile} = $content;

--- a/t/rt-89404.t
+++ b/t/rt-89404.t
@@ -1,0 +1,30 @@
+use Test::More tests => 1;
+
+use File::Temp;
+use Test::Reporter;
+my($ft) = File::Temp->new(TEMPLATE => "bugdemo-XXXX", SUFFIX=>".rpt");
+print $ft <<EOF;
+From: andreas.koenig.gmwojprw@franz.ak.mind.de
+X-Test-Reporter-Distfile: DLAND/BSD-Process-0.07.tar.gz
+X-Test-Reporter-Perl: v5.18.0
+Subject: FAIL BSD-Process-0.07 amd64-freebsd 9.2-release
+Report: This distribution has been tested as part of the CPAN Testers
+project, supporting the Perl programming language.  See
+http://wiki.cpantesters.org/ for more information or email
+questions to cpan-testers-discuss@perl.org
+
+
+--
+Dear David Landgren,
+[...]
+Summary of my perl5 (revision 5 version 18 subversion 0) configuration:
+  Commit id: a9acda3b5f74585852a57b51b724804ac586cb0b
+  Platform:
+    osname=freebsd, osvers=9.2-release, archname=amd64-freebsd
+EOF
+$ft->flush;
+my $file = $ft->filename;
+my $r = Test::Reporter->new(
+                            transport => 'Metabase',
+)->read($file);
+is $r->{_perl_version}{_archname}, "amd64-freebsd";


### PR DESCRIPTION
This pr contains the test posted to and fixes the bug described in https://rt.cpan.org/Ticket/Display.html?id=89404

Enjoy && Thanks,
